### PR TITLE
fix：主题git方式分支修正

### DIFF
--- a/content/1.getting-started/2.installation.md
+++ b/content/1.getting-started/2.installation.md
@@ -23,7 +23,7 @@ There are numerous ways to install the theme—simply choose the method you pref
 1. Install Using Git 
 
 ```bash
-git clone -b main https://github.com/everfu/hexo-theme-solitude.git themes/solitude
+git clone -b dev https://github.com/everfu/hexo-theme-solitude.git themes/solitude
 ```
 
 2. Manual Installation via Theme Files

--- a/content/cn/1.getting-started/2.installation.md
+++ b/content/cn/1.getting-started/2.installation.md
@@ -23,7 +23,7 @@ cd [project-name]
 1. 使用 Git 安装 
 
 ```bash
-git clone -b main https://github.com/everfu/hexo-theme-solitude.git themes/solitude
+git clone -b dev https://github.com/everfu/hexo-theme-solitude.git themes/solitude
 ```
 
 2. 自行下载主题文件安装 


### PR DESCRIPTION
主题仓库分支为dev，文档教程clone的是main